### PR TITLE
Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What kind of an issue is this?
+
+- [ ] Bug report
+- [ ] Feature request
+
+
+## What is the expected behaviour?
+
+
+## What is the current behaviour?
+
+<!-- if this is a bug report -->
+
+
+## How do you reproduce this problem? 
+
+<!-- if this is a bug report -->
+<!-- provide steps to reproduce this problem, preferably in a bullet point list -->
+
+
+## Other information
+
+<!-- include screenshots if appropriate -->
+<!-- add labels you see fit. please do not exaggerate. -->


### PR DESCRIPTION
Adding a template on github issues, this will automatically show when creating a new issue on github.
First commit didn't go through, thus resulting in weird commit message.
Added 1 file