### PR TITLE
fixed css order to help tidligere_konserter display almost correctly

### DIFF
--- a/webapp/static/css/main.css
+++ b/webapp/static/css/main.css
@@ -25,9 +25,7 @@ body, html {
   display: none;
 }
 
-.sjangerkonserter {
-  display: none;
-}
+
 .nav-link, h1{
   font-family: 'Audiowide', cursive;
 }
@@ -45,7 +43,9 @@ body, html {
 }
 
 
-  
+.sjangerkonserter {
+  display: none;
+}
 
 
 /* Bruk pressable klassen på headers som det skal være mulig å trykke på */

--- a/webapp/templates/webapp/bookingansvarlig_tidligere_konserter.html
+++ b/webapp/templates/webapp/bookingansvarlig_tidligere_konserter.html
@@ -29,7 +29,7 @@ Om en festival pågår, altså at en konsert fra fortiden og en fremtiden har sa
      {% for band in konsert.band.all %}
       {% if band.sjanger == sjanger %}
 
-        <div class="sjangerkonserter col-sm-4 col" id="{{sjanger}}">
+        <div class="col-sm-4 col sjangerkonserter" id="{{sjanger}}">
           <h3>{{konsert.konsert}}</h3>
           <p>Band: {{ konsert.band.all|unordered_list}}</p>
 


### PR DESCRIPTION
tidligere_konserter wfm
 - usertest.json
 - endre 1 konsert fra tidligere til et annet festivalnavn
 - sjekk at bandet sitt sjanger displayes
 
fixer ingen bugs, bare gjør at noe som ikke funka funker som det gjorde tidligere. Ikke riktig, men nok til å vise demo.